### PR TITLE
Support standalone builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,39 +24,104 @@ on:
         required: false
 
 jobs:
-  build:
+  deps:
     runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache DMG file
+      - name: Cache deps
         if: inputs.cache
         uses: actions/cache@v3
         with:
-          path: |
-            build/*.dmg
-          key: dmg-${{ inputs.openfoam-version }}-${{ runner.arch }}-${{ hashFiles('Brewfile', 'configure.sh', 'icon.icns', 'Makefile', format('OpenFOAM-v${0}.tgz.sha256', inputs.openfoam-version)) }}
-      - name: Reuse cached DMG if possible
+          path: build/*-deps.sparsebundle
+          key: deps-${{ inputs.openfoam-version }}-${{ runner.arch }}-${{ hashFiles('Brewfile', 'Makefile') }}
+      - name: Reuse cached deps if possible
         run: |
-          touch -c build/*.dmg
-      - name: Build
+          touch -c build/*-deps.sparsebundle
+      - name: Make deps
         run: >
-          make zip
+          make deps
           OPENFOAM_VERSION=${{ inputs.openfoam-version }}
-          APP_VERSION=${{ inputs.app-version }}
-          ${{ inputs.source-tarball-url != '' && format('SOURCE_TARBALL_URL={0}', inputs.source-tarball-url) || '' }}
-      - name: Upload ZIP artifact
+      - name: Upload deps artifact
         uses: actions/upload-artifact@v3
         with:
-          name: zip-${{ inputs.openfoam-version }}
+          name: deps-${{ inputs.openfoam-version }}-${{ runner.arch }}
+          path: build/*-deps.sparsebundle
+          if-no-files-found: error
+
+  build:
+    needs: deps
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download deps artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: deps-${{ inputs.openfoam-version }}-${{ runner.arch }}
+          path: build
+      - name: Use deps artifact
+        run: |
+          touch -c build/*-deps.sparsebundle
+      - name: Cache build
+        if: inputs.cache
+        uses: actions/cache@v3
+        with:
+          path: build/*-build.sparsebundle
+          key: build-${{ inputs.openfoam-version }}-${{ runner.arch }}-${{ hashFiles('build/*-deps.sparsebundle', 'configure.sh', 'Makefile', format('OpenFOAM-v${0}.tgz.sha256', inputs.openfoam-version)) }}
+      - name: Reuse cached build if possible
+        run: |
+          touch -c build/*-build.sparsebundle
+      - name: Build
+        run: >
+          make build
+          OPENFOAM_VERSION=${{ inputs.openfoam-version }}
+          ${{ inputs.source-tarball-url != '' && format('SOURCE_TARBALL_URL={0}', inputs.source-tarball-url) || '' }}
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ inputs.openfoam-version }}-${{ runner.arch }}
+          path: build/*-build.sparsebundle
+          if-no-files-found: error
+
+  app:
+    needs: build
+    strategy:
+      matrix:
+        dependencies-kind: [standalone, homebrew]
+      fail-fast: false
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-${{ inputs.openfoam-version }}-${{ runner.arch }}
+          path: build
+      - name: Use build artifact
+        run: |
+          touch -c build/*-build.sparsebundle
+      - name: Build zipped app
+        run: >
+          make zip
+          APP_VERSION=${{ inputs.app-version }}
+          DEPENDENCIES_KIND=${{ matrix.dependencies-kind }}
+          OPENFOAM_VERSION=${{ inputs.openfoam-version }}
+          ${{ inputs.source-tarball-url != '' && format('SOURCE_TARBALL_URL={0}', inputs.source-tarball-url) || '' }}
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: zip-${{ inputs.openfoam-version }}-${{ matrix.dependencies-kind }}-${{ runner.arch }}
           path: build/*-app-*.zip
           if-no-files-found: error
 
   test:
-    needs: build
+    needs: app
     strategy:
       matrix:
         os: [macos-10.15, macos-11, macos-12]
+        dependencies-kind: [standalone, homebrew]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,31 +130,41 @@ jobs:
       - name: Download ZIP artifact
         uses: actions/download-artifact@v3
         with:
-          name: zip-${{ inputs.openfoam-version }}
+          name: zip-${{ inputs.openfoam-version }}-${{ matrix.dependencies-kind }}-${{ runner.arch }}
           path: build
       - name: Unzip app
         run: |
-          unzip *-app-homebrew-$(uname -m).zip
+          unzip *-app-*.zip
         working-directory: build
-      - name: Test
+      - name: Install Homebrew dependencies
+        if: matrix.dependencies-kind == 'homebrew'
         run: |
-          make install-dependencies OPENFOAM_VERSION=${{ inputs.openfoam-version }}
-          make test OPENFOAM_VERSION=${{ inputs.openfoam-version }}
+          brew bundle --verbose
+      - name: Test
+        run: >
+          make test
+          APP_VERSION=${{ inputs.app-version }}
+          OPENFOAM_VERSION=${{ inputs.openfoam-version }}
+          DEPENDENCIES_KIND=${{ matrix.dependencies-kind }}
 
   release:
-    if: ${{ inputs.release }}
     needs: test
+    if: inputs.release
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dependencies-kind: [standalone, homebrew]
+      fail-fast: false
     steps:
-      - name: Download ZIP artifact
+      - name: Download zip artifact
         uses: actions/download-artifact@v3
         with:
-          name: zip-${{ inputs.openfoam-version }}
-      - name: Upload ZIP to release
+          name: zip-${{ inputs.openfoam-version }}-${{ matrix.dependencies-kind }}-${{ runner.arch }}
+      - name: Upload zip to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: '*.zip'
+          file: '*-app-*.zip'
           tag: ${{ github.ref }}
           file_glob: true
           overwrite: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
   openfoam2206:
     needs: get-version
-    name: OpenFOAM-v2206.app
+    name: OpenFOAM v2206
     uses: ./.github/workflows/build-test.yml
     with:
       openfoam-version: 2206
@@ -27,7 +27,7 @@ jobs:
 
   openfoam2112:
     needs: get-version
-    name: OpenFOAM-v2112.app
+    name: OpenFOAM v2112
     uses: ./.github/workflows/build-test.yml
     with:
       openfoam-version: 2112

--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleIconFile</key>
     <string>icon.icns</string>
     <key>CFBundleVersion</key>
-    <string>{{APP_VERSION}}-homebrew-{{ARCH}}</string>
+    <string>{{APP_VERSION}}-{{DEPENDENCIES_KIND}}-{{ARCH}}</string>
     <key>CFBundleShortVersionString</key>
     <string>{{APP_VERSION}}</string>
 </dict>

--- a/Contents/MacOS/bashrc
+++ b/Contents/MacOS/bashrc
@@ -4,7 +4,9 @@ SCRIPT_DIR="$(\cd $(dirname ${BASH_SOURCE:-${ZSH_NAME:+$0}}) && \pwd -L)"
 
 VOLUME=`"$SCRIPT_DIR/volume" -show-prefix`
 
-# Keep the volume directory open in this process (prevents accidental ejection)
-exec {fd}<"$VOLUME"
+if [ ${BASH_VERSINFO:-4} -ge 4 ]; then
+    # Keep the volume directory open in this process (prevents accidental ejection)
+    exec {fd}<"$VOLUME"
+fi
 
 . "$VOLUME/etc/bashrc"

--- a/Contents/MacOS/openfoam
+++ b/Contents/MacOS/openfoam
@@ -19,4 +19,4 @@ VOLUME=$("$APP_BUNDLE/Contents/MacOS/volume" -show-prefix)
 exec {fd}<"$VOLUME"
 
 echo "Activating the OpenFOAM environment..."
-exec bash "$VOLUME/etc/openfoam" "$@"
+PATH="$VOLUME/usr/bin:$PATH" exec bash "$VOLUME/etc/openfoam" "$@"

--- a/Contents/MacOS/volume
+++ b/Contents/MacOS/volume
@@ -88,7 +88,7 @@ case "$1" in
             $QUIET || echo "The $APP_NAME volume is already mounted."
         else
             $QUIET || echo "Mounting the $APP_NAME volume..."
-            if ! hdiutil attach -quiet "$DMG_FILE"; then
+            if ! hdiutil attach -quiet -noverify "$DMG_FILE"; then
                 echo "ERROR: Failed to mount the $APP_NAME volume" 1>&2
                 exit 1
             fi

--- a/configure.sh
+++ b/configure.sh
@@ -1,29 +1,23 @@
 #!/bin/bash -e
 
-SYSTEM_COMPILER="Clang"
-
-ADIOS_PATH='`brew --prefix adios2`'
-BOOST_PATH='`brew --prefix boost`'
-CGAL_PATH='`brew --prefix cgal\@4`'
-FFTW_PATH='`brew --prefix fftw`'
-KAHIP_PATH='`brew --prefix kahip`'
-METIS_PATH='`brew --prefix metis`'
-SCOTCH_PATH='`brew --prefix scotch-no-pthread`'
-
-LIBOMP_PATH='`brew --prefix libomp`'
-GMP_PATH='`brew --prefix gmp`'
-MPFR_PATH='`brew --prefix mpfr`'
-
-
 bin/tools/foamConfigurePaths \
-    -system-compiler "$SYSTEM_COMPILER" \
-    -adios-path "$ADIOS_PATH"  \
-    -boost-path "$BOOST_PATH"  \
-    -cgal-path "$CGAL_PATH"  \
-    -fftw-path "$FFTW_PATH"  \
-    -kahip-path "$KAHIP_PATH"  \
-    -metis-path "$METIS_PATH"  \
-    -scotch-path "$SCOTCH_PATH"
+    -system-compiler 'Clang' \
+    -adios-path $PWD/usr/opt/adios2 \
+    -boost-path $PWD/usr/opt/boost \
+    -cgal-path $PWD/usr/opt/cgal\\\@4 \
+    -fftw-path $PWD/usr/opt/fftw \
+    -kahip-path $PWD/usr/opt/kahip \
+    -metis-path $PWD/usr/opt/metis \
+    -scotch-path $PWD/usr/opt/scotch-no-pthread
+
+
+echo "export PATH=\"$PWD/usr/bin:\${PATH+:\$PATH}\"" >> etc/prefs.sh
+echo "setenv PATH $PWD/usr/bin:\$PATH;" >> etc/prefs.csh
+
+
+LIBOMP_PATH="$PWD/usr/opt/libomp"
+GMP_PATH="$PWD/usr/opt/gmp"
+MPFR_PATH="$PWD/usr/opt/mpfr"
 
 CPATH="$LIBOMP_PATH/include:$GMP_PATH/include:$MPFR_PATH/include"
 LIBRARY_PATH="$LIBOMP_PATH/lib:$GMP_PATH/lib:$MPFR_PATH/lib"
@@ -32,6 +26,7 @@ echo "export CPATH=\"$CPATH\"" >> etc/prefs.sh
 echo "setenv CPATH \"$CPATH\"" >> etc/prefs.csh
 echo "export LIBRARY_PATH=\"$LIBRARY_PATH\"" >> etc/prefs.sh
 echo "setenv LIBRARY_PATH \"$LIBRARY_PATH\"" >> etc/prefs.csh
+
 
 echo 'export FOAM_DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH"' >> etc/bashrc
 echo 'setenv FOAM_DYLD_LIBRARY_PATH "$DYLD_LIBRARY_PATH"' >> etc/cshrc


### PR DESCRIPTION
Trying out a fully standalone (i.e., no system-wide Homebrew installation required) build, as suggested and discussed [here](https://www.reddit.com/r/OpenFOAM/comments/voiy4i/comment/iefbjge/?utm_source=share&utm_medium=web2x&context=3).

In the standalone build, a full Homebrew install is packaged inside the virtual disk. This adds ~2 GB to the app size, which is a lot. OTOH, with the regular build, you'd have to install the same stuff anyway (although in that case it can be shared between OpenFOAM versions; and precompiled bottles can be used instead of building everything from source). **EDIT: the internal Homebrew install can be cleaned up, so it's a little less than 2 GB, and it might be an acceptable compromise to many (most?) users (and especially non-Homebrew users). Standalone builds are also less likely to break due to upgraded dependencies, and the user should not even need a compiler (Xcode or CLT) to use them (unless they actually need to compile something). Build times for dependencies that do not have relocatable Homebrew bottles still add significant time (see below). Building the app no longer requires a system Homebrew install**

This draft PR is 100% experimental, and likely to fail CI for exceeding the 6-hour job time limit... **EDIT: I did have to split the build workflows into two separate jobs to stop us from hitting that limit. It still takes ~6 hours for a full build on macOS runners (~2 hours for dependencies + ~4 hours for OpenFOAM itself; note that macOS runners are not the fastest), which is a lot of time (but caching can somewhat help here). All in all I've started to like this idea a lot more than when I first tried it**

**EDIT: Extra details follow**
I refined this PR by adopting a similar approach to https://github.com/octave-app/octave-app-bundler (I'd like acknowledge the maintainer of that project, @apjanke, who coincidentally also started a [project](https://github.com/apjanke/homebrew-openfoam) attempting to build OpenFOAM for Mac with Homebrew). Dependencies are installed under a new `usr` directory in the volume using Homebrew. On standalone builds, the Homebrew installation itself is stripped from the volume, leaving only the dependencies. On non-standalone builds (which are still possible by setting the make variable `DEPENDENCIES_KIND=homebrew`), the `usr` directory is replaced with a symlink to the Homebrew prefix location (which is also backwards compatible with apps built prior to this PR).