### PR TITLE
Build with fewer dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,13 +7,13 @@ brew "open-mpi"
 brew "libomp"
 brew "boost"
 brew "fftw"
-brew "kahip"
-brew "metis"
 brew "gerlero/openfoam/cgal@4"
 brew "gerlero/openfoam/scotch-no-pthread"
 
 # Optional dependencies (uncomment to enable)
 # brew "adios2"
+# brew "kahip"
+# brew "metis"
 
 # Optional tools
 brew "bash"


### PR DESCRIPTION
Build using the same dependencies as those required by official Ubuntu packages (i.e., drop ~~`adios2`~~[EDIT: already removed in #135], `kahip` and `metis` as dependencies)