### PR TITLE
Fix compatibility symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(INSTALL_DIR)/$(APP_NAME).app: build/$(APP_NAME).app
 	cp -r build/$(APP_NAME).app $(INSTALL_DIR)/
 
 build/$(DIST_NAME).zip: build/$(APP_NAME).app
-	cd build && zip -r $(DIST_NAME).zip $(APP_NAME).app
+	cd build && zip -r --symlinks $(DIST_NAME).zip $(APP_NAME).app
 	shasum -a 256 build/$(DIST_NAME).zip
 
 build/$(APP_NAME).app: $(APP_CONTENTS)


### PR DESCRIPTION
Fix compatibility symlinks for scripts (introduced in #78) not surviving the app being zipped