### PR TITLE
Revert "Drop macOS 10.15 from workflows"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   deps:
-    runs-on: macos-11
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
   
   build:
     needs: deps
-    runs-on: macos-11
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
       matrix:
         dependencies-kind: [standalone, homebrew]
       fail-fast: false
-    runs-on: macos-11
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -121,7 +121,7 @@ jobs:
     needs: app
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-10.15, macos-11, macos-12]
         dependencies-kind: [standalone, homebrew]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Reverts gerlero/openfoam-app#66, as deprecation of macOS 10.15 images has been postponed (https://github.com/actions/runner-images/issues/5583#issuecomment-1219501124)