### PR TITLE
Fix brew bundle warning

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+tap "gerlero/openfoam"
+
 # Required dependencies
 brew "open-mpi"
 brew "libomp"


### PR DESCRIPTION
Fixes the warning `Warning: 'gerlero/openfoam/cgal@4' formula is unreadable: No available formula with the name "gerlero/openfoam/cgal@4".` when running `brew bundle`.