### PR TITLE
Work around Open MPI TMPDIR truncation issue

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -49,3 +49,8 @@ echo 'setenv FOAM_DYLD_LIBRARY_PATH "$DYLD_LIBRARY_PATH"' >> etc/cshrc
 
 # Workaround for https://develop.openfoam.com/Community/integration-cfmesh/-/issues/8
 sed -i '' 's|LIB_LIBS =|& $(LINK_OPENMP) |' modules/cfmesh/meshLibrary/Make/options
+
+
+# Workaround for https://github.com/open-mpi/ompi/issues/7393
+echo 'export TMPDIR=/tmp' >> etc/prefs.sh
+echo 'setenv TMPDIR /tmp' >> etc/prefs.csh

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,7 @@ rm -rf flange
 cp -r "$FOAM_TUTORIALS/basic/laplacianFoam/flange" flange
 cd flange
 OMPI_MCA_rmaps_base_oversubscribe=1 ./Allrun-parallel
+! grep 'A system call failed' log.*
 reconstructPar
 cd ..
 


### PR DESCRIPTION
https://www.cfd-online.com/Forums/openfoam-installation/242731-native-openfoam-macos-openfoam-v2112-app-install-instructions-github-link.html#post840396

https://github.com/open-mpi/ompi/issues/7393