### PR TITLE
Revert to using scotch-no-pthread formula

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+tap "gerlero/openfoam"
+
 # Required dependencies
 brew "open-mpi"
 
@@ -6,7 +8,7 @@ brew "libomp"
 brew "boost"
 brew "cgal"
 brew "fftw"
-brew "scotch"
+brew "gerlero/openfoam/scotch-no-pthread"
 
 # Optional dependencies (uncomment to enable)
 # brew "adios2"

--- a/configure.sh
+++ b/configure.sh
@@ -13,7 +13,7 @@ bin/tools/foamConfigurePaths \
     -fftw-path $PWD/usr/opt/fftw \
     -kahip-path $PWD/usr/opt/kahip \
     -metis-path $PWD/usr/opt/metis \
-    -scotch-path $PWD/usr/opt/scotch
+    -scotch-path $PWD/usr/opt/scotch-no-pthread
 
 
 # Set path to the MPI install


### PR DESCRIPTION
Reverts the changes of #141 related to Scotch as a possible fix for #7.

Note that `gerlero/openfoam/scotch-no-pthread` is at major version 6, and upgrading that formula to the latest version (7) might not be possible without breaking the current release of the app when installed with Homebrew.