### PR TITLE
Revert "Drop KaHIP and METIS dependencies from default builds"

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -8,12 +8,12 @@ brew "libomp"
 brew "boost"
 brew "cgal"
 brew "fftw"
+brew "kahip"
+brew "metis"
 brew "gerlero/openfoam/scotch-no-pthread"
 
 # Optional dependencies (uncomment to enable)
 # brew "adios2"
-# brew "kahip"
-# brew "metis"
 
 # Optional tools
 brew "bash"


### PR DESCRIPTION
This reverts commit a29ea85022e73ef4861e3501c5121f52f722e6c4.