### PR TITLE
Fix install names in binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,13 @@ build/$(APP_NAME).app/Contents/%: Contents/%
 	mkdir -p $(@D)
 	cp -a $< $@
 
-build/$(APP_NAME).app/Contents/Resources/$(APP_NAME).dmg: build/$(APP_NAME)-build.sparsebundle build/$(APP_NAME).app/Contents/Resources/icon.icns
+build/$(APP_NAME).app/Contents/Resources/$(APP_NAME).dmg: build/$(APP_NAME)-build.sparsebundle build/$(APP_NAME).app/Contents/Resources/icon.icns fix_install_names.sh
 	[ ! -d $(VOLUME) ] || hdiutil detach $(VOLUME)
 	hdiutil attach \
 		build/$(APP_NAME)-build.sparsebundle \
 		-shadow
+	cd $(VOLUME) \
+		&& "$(CURDIR)/fix_install_names.sh"
 	cp build/$(APP_NAME).app/Contents/Resources/icon.icns $(VOLUME)/.VolumeIcon.icns
 	SetFile -c icnC $(VOLUME)/.VolumeIcon.icns
 	SetFile -a C $(VOLUME)

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ test-dmg:
 	cd $(TEST_DIR)/test-dmg \
 		&& source $(VOLUME)/etc/bashrc \
 		&& foamInstallationTest \
-		&& bash -ex "$(CURDIR)/test.sh"
+		&& "$(CURDIR)/test.sh"
 	hdiutil detach $(VOLUME)
 
 clean-app:

--- a/fix_install_names.sh
+++ b/fix_install_names.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+# -----------------------------------------------------------------------------
+# Fix install names of libraries and binaries so that they load the MPI-enabled
+# variants of libraries by default (instead of the "dummy" ones that don't work
+# in parallel).
+#
+# This makes the installation less prone to runtime errors caused by the dummy
+# libraries being loaded as a consequence of the System Integrity Protection
+# (SIP) feature of macOS, which can clear the $DYLD_LIBRARY_PATH set by
+# OpenFOAM.
+#
+# Discussed at https://develop.openfoam.com/Development/openfoam/-/issues/2801
+# -----------------------------------------------------------------------------
+
+source etc/bashrc
+
+fix_install_names() {
+    for dummylib in $FOAM_LIBBIN/dummy/lib*; do
+        install_name_tool \
+            -change \
+                "$dummylib" \
+                "$FOAM_LIBBIN/$FOAM_MPI/$(basename "$dummylib")" \
+            "$1"
+    done
+}
+
+for lib in $FOAM_LIBBIN/lib*; do
+    fix_install_names "$lib"
+done
+
+for bin in $FOAM_APPBIN/*; do
+    fix_install_names "$bin"
+done


### PR DESCRIPTION
An extra layer that should help in avoiding SIP-related errors.

See discussion in the comments at https://develop.openfoam.com/Development/openfoam/-/issues/2801