### PR TITLE
Build OpenFOAM v2306 from Git tag

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ env:
     ${{ inputs.openfoam-tarball-url != '' && format('OPENFOAM_TARBALL_URL={0}', inputs.openfoam-tarball-url) || '' }}
     ${{ inputs.openfoam-git-branch != '' && format('OPENFOAM_GIT_BRANCH={0}', inputs.openfoam-git-branch) || '' }}
   
-  OPENFOAM: ${{ inputs.openfoam-git-branch || inputs.openfoam-version }}
+  OPENFOAM: ${{ inputs.openfoam-version || inputs.openfoam-git-branch }}
   
   BUILD_OS: ${{ inputs.build-os || 'macos-11' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
   ci:
     strategy:
       matrix:
-        openfoam-version: [2212, 2206, 2112]
+        openfoam-version: [2306, 2212, 2206, 2112]
         include:
+          - openfoam-version: 2306
+            openfoam-git-branch: OpenFOAM-v2306
           - openfoam-version: 2212
             openfoam-tarball-url: https://dl.openfoam.com/source/v2212/OpenFOAM-v2212_230612.tgz
           - openfoam-version: 2112
@@ -42,6 +44,7 @@ jobs:
     with:
       openfoam-version: ${{ matrix.openfoam-version }}
       openfoam-tarball-url: ${{ matrix.openfoam-tarball-url }}
+      openfoam-git-branch: ${{ matrix.openfoam-git-branch }}
       build-os: ${{ inputs.build-os }}
       use-cached: ${{ github.event_name == 'workflow_dispatch' && inputs.use-cached || github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' }}
       cache-build: ${{ github.event_name != 'workflow_dispatch' && inputs.cache-build || github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,10 @@ jobs:
     needs: get-version
     strategy:
       matrix:
-        openfoam-version: [2212, 2206, 2112]
+        openfoam-version: [2306, 2212, 2206, 2112]
         include:
+          - openfoam-version: 2306
+            openfoam-git-branch: OpenFOAM-v2306
           - openfoam-version: 2212
             openfoam-tarball-url: https://dl.openfoam.com/source/v2212/OpenFOAM-v2212_230612.tgz
           - openfoam-version: 2112
@@ -30,5 +32,6 @@ jobs:
     with:
       openfoam-version: ${{ matrix.openfoam-version }}
       openfoam-tarball-url: ${{ matrix.openfoam-tarball-url }}
+      openfoam-git-branch: ${{ matrix.openfoam-git-branch }}
       app-version: ${{ needs.get-version.outputs.app-version }}
       release: true


### PR DESCRIPTION
Fetch v2306 sources by cloning the corresponding tag from the upstream Git repo (until https://develop.openfoam.com/Development/openfoam/-/issues/2927 is resolved)