### PR TITLE
Drop tarball URL override for OpenFOAM v2306

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
     with:
       openfoam-version: ${{ matrix.openfoam-version }}
       openfoam-tarball-url: ${{ matrix.openfoam-tarball-url }}
-      openfoam-git-branch: ${{ matrix.openfoam-git-branch }}
       build-os: ${{ inputs.build-os }}
       use-cached: ${{ github.event_name == 'workflow_dispatch' && inputs.use-cached || github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' }}
       cache-build: ${{ github.event_name != 'workflow_dispatch' && inputs.cache-build || github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         openfoam-version: [2306, 2212, 2206, 2112]
         include:
           - openfoam-version: 2306
-            openfoam-tarball-url: https://dl.openfoam.com/source/latest/OpenFOAM-v2306.tgz
           - openfoam-version: 2212
             openfoam-tarball-url: https://dl.openfoam.com/source/v2212/OpenFOAM-v2212_230612.tgz
           - openfoam-version: 2112

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         openfoam-version: [2306, 2212, 2206, 2112]
         include:
           - openfoam-version: 2306
-            openfoam-tarball-url: https://dl.openfoam.com/source/latest/OpenFOAM-v2306.tgz
           - openfoam-version: 2212
             openfoam-tarball-url: https://dl.openfoam.com/source/v2212/OpenFOAM-v2212_230612.tgz
           - openfoam-version: 2112

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,5 @@ jobs:
     with:
       openfoam-version: ${{ matrix.openfoam-version }}
       openfoam-tarball-url: ${{ matrix.openfoam-tarball-url }}
-      openfoam-git-branch: ${{ matrix.openfoam-git-branch }}
       app-version: ${{ needs.get-version.outputs.app-version }}
       release: true


### PR DESCRIPTION
See #172. https://develop.openfoam.com/Development/openfoam/-/issues/2927 is now fixed.