### PR TITLE
Use latest Scotch

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,3 @@
-tap "gerlero/openfoam"
-
 # Required dependencies
 brew "open-mpi"
 brew "libomp"
@@ -10,7 +8,7 @@ brew "cgal"
 brew "fftw"
 brew "kahip"
 brew "metis"
-brew "gerlero/openfoam/scotch-no-pthread"
+brew "scotch"
 
 # Optional dependencies (uncomment to enable)
 # brew "adios2"

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -13,7 +13,7 @@ bin/tools/foamConfigurePaths \
     -fftw-path '$WM_PROJECT_DIR/usr/opt/fftw' \
     -kahip-path '$WM_PROJECT_DIR/usr/opt/kahip' \
     -metis-path '$WM_PROJECT_DIR/usr/opt/metis' \
-    -scotch-path '$WM_PROJECT_DIR/usr/opt/scotch-no-pthread'
+    -scotch-path '$WM_PROJECT_DIR/usr/opt/scotch'
 
 
 # Set path to the MPI install


### PR DESCRIPTION
Default-built Scotch should work as of their 7.0.4 release. See: https://gitlab.inria.fr/scotch/scotch/-/issues/33

Closes #7